### PR TITLE
Add tag_filter setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ dependencies:
           tag_prefix: raven-js@
           # include semver pre-releases
           prereleases: true
+
+      https://github.com/libevent/libevent.git:
+        replace_in_files:
+        - filename: file.txt
+          pattern: libevent (\S+)
+          # filter tags to those that match a specific pattern, and use the captured
+          # group as the version name (i.e. you'll get "2.1.10" instead of "release-2.1.10")
+          tag_filter: 'release-(\S+)-stable'
+
+      https://github.com/libevent/libevent.git:
+        replace_in_files:
+        - filename: file.txt
+          pattern: libevent (\S+)
+          # filter tags to those that match a specific pattern, and use the
+          # full tag name as the version
+          tag_filter: 'release-\S+-stable'
 ```
 
 ## Support

--- a/remotes.go
+++ b/remotes.go
@@ -20,6 +20,7 @@ type replaceInFile struct {
 	Filename    string `json:"filename"`
 	Pattern     string `json:"pattern"`
 	TagPrefix   string `json:"tag_prefix"`
+	TagFilter   string `json:"tag_filter"`
 	Semver      *bool  `json:"semver"`
 	Prereleases bool   `json:"prereleases"`
 	Range       string `json:"range"`
@@ -58,20 +59,28 @@ func (rif *replaceInFile) writeFile(contents string) {
 }
 
 func (rif *replaceInFile) getLatestTag(tags []string) string {
-	if rif.TagPrefix != "" {
+	if rif.TagPrefix != "" && rif.TagFilter != "" {
+		panic("Cannot use tag_prefix and tag_filter together. Please choose one.")
+	} else if rif.TagPrefix != "" {
 		fmt.Printf("Filtering to tags with prefix %s and removing it", rif.TagPrefix)
 		tags = filterAndRemovePrefixes(tags, rif.TagPrefix)
+		fmt.Printf("Remaining tags: %v\n", tags)
+	} else if rif.TagFilter != "" {
+		fmt.Printf("Filtering tags using %s", rif.TagFilter)
+		tags = filter(tags, rif.TagFilter)
 		fmt.Printf("Remaining tags: %v\n", tags)
 	}
 
 	// Enabled if not set
 	if rif.Semver == nil || *rif.Semver {
 		versions := stringsToVersions(tags, rif.Range, rif.Prereleases)
-		if len(versions) < 1 && rif.TagPrefix == "" {
-			// Try automatically removing "v" since it's so common
+
+		// Try automatically removing "v" since it's so common
+		if len(versions) < 1 && rif.TagPrefix == "" && rif.TagFilter == "" {
 			tags = filterAndRemovePrefixes(tags, "v")
 			versions = stringsToVersions(tags, rif.Range, rif.Prereleases)
 		}
+
 		tags = versionsToStrings(versions)
 	}
 
@@ -123,6 +132,22 @@ func filterAndRemovePrefixes(tags []string, prefix string) []string {
 	for _, s := range tags {
 		if strings.HasPrefix(s, prefix) {
 			filtered = append(filtered, s[len(prefix):])
+		}
+	}
+	return filtered
+}
+
+func filter(tags []string, f string) []string {
+	regex := regexp.MustCompile(f)
+	filtered := []string{}
+	for _, s := range tags {
+		submatches := regex.FindStringSubmatch(s)
+		if len(submatches) == 1 {
+			// No group captured
+			filtered = append(filtered, submatches[0])
+		} else if len(submatches) == 2 {
+			// Group captured
+			filtered = append(filtered, submatches[1])
 		}
 	}
 	return filtered

--- a/test/filter/dependencies.json
+++ b/test/filter/dependencies.json
@@ -1,0 +1,24 @@
+{
+  "manifests": {
+    "": {
+      "current": {
+        "dependencies": {
+          "https://github.com/libevent/libevent.git": {
+            "constraint": "release-2.1.10-stable",
+            "source": "git",
+            "repo": "https://github.com/libevent/libevent.git"
+          }
+        }
+      },
+      "updated": {
+        "dependencies": {
+          "https://github.com/libevent/libevent.git": {
+            "constraint": "release-2.1.8-stable",
+            "source": "git",
+            "repo": "https://github.com/libevent/libevent.git"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/filter/dependencies_capture.json
+++ b/test/filter/dependencies_capture.json
@@ -1,0 +1,24 @@
+{
+  "manifests": {
+    "": {
+      "current": {
+        "dependencies": {
+          "https://github.com/libevent/libevent.git": {
+            "constraint": "2.1.10",
+            "source": "git",
+            "repo": "https://github.com/libevent/libevent.git"
+          }
+        }
+      },
+      "updated": {
+        "dependencies": {
+          "https://github.com/libevent/libevent.git": {
+            "constraint": "2.1.11",
+            "source": "git",
+            "repo": "https://github.com/libevent/libevent.git"
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/filter/deps_tests.yml
+++ b/test/filter/deps_tests.yml
@@ -1,0 +1,29 @@
+tests:
+- name: filter
+  repo: repo_current
+  diff: repo_updated
+  data: dependencies.json
+  user_config:
+    path: /
+    settings:
+      remotes:
+        https://github.com/libevent/libevent.git:
+          replace_in_files:
+          - filename: file.txt
+            pattern: libevent==(\S+)
+            semver: false  # uncaptured example won't work with semver
+            tag_filter: 'release-\S+-stable'
+
+- name: filter
+  repo: repo_current
+  diff: repo_updated_capture
+  data: dependencies_capture.json
+  user_config:
+    path: /
+    settings:
+      remotes:
+        https://github.com/libevent/libevent.git:
+          replace_in_files:
+          - filename: file.txt
+            pattern: libevent-captured==(\S+)
+            tag_filter: 'release-(\S+)-stable'

--- a/test/filter/repo_current/file.txt
+++ b/test/filter/repo_current/file.txt
@@ -1,0 +1,2 @@
+libevent==release-2.1.10-stable
+libevent-captured==2.1.10

--- a/test/filter/repo_updated/file.txt
+++ b/test/filter/repo_updated/file.txt
@@ -1,0 +1,2 @@
+libevent==release-2.1.8-stable
+libevent-captured==2.1.10

--- a/test/filter/repo_updated_capture/file.txt
+++ b/test/filter/repo_updated_capture/file.txt
@@ -1,0 +1,2 @@
+libevent==release-2.1.10-stable
+libevent-captured==2.1.11


### PR DESCRIPTION
Allows you to filter tags using more specific regular expressions, and even capture the part of the tag name that you want to use as the version name (that is used when replacing strings in files, titles of PRs, etc.).